### PR TITLE
Updated requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.0.1
 mysql-connector-python==8.0.26
+Werkzeug==2.2.2


### PR DESCRIPTION
Werkzeug version was not mentioned in the requirements file. Following which werkzeug=3.x.x version was getting installed. But it was causing import error and not working as intended. werkzeug=2.2.2 works fine with flask=2.0.1 and solves the import error.